### PR TITLE
Fix typo in selector

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -34,7 +34,7 @@ $pageloader-opacity: 1 !default
   transition: transform .35s ease-out,-webkit-transform .35s ease-out
   will-change: transform
   &:not(.is-left-to-right),
-  &:not(.is-right-to-left)
+  &:not(.is-right-to-left),
   &:not(.is-bottom-to-top)
     -webkit-transform: translateY(-100%)
     transform: translateY(-100%)


### PR DESCRIPTION
Added this repo to a project of mine which went through some css processing where it complained about line 37 and 38 being dead lines of code. I'm fairly new to CSS and SCSS but I believe my edit was the original intent which was broken with a feature request.